### PR TITLE
removed more unnecessary fields.

### DIFF
--- a/homeassistant/components/device_tracker/gplus.py
+++ b/homeassistant/components/device_tracker/gplus.py
@@ -25,7 +25,6 @@ CONF_SSID = 'cookie_ssid'
 CONF_HSID = 'cookie_hsid'
 CONF_FREQ = 'data_freq'
 CONF_AT = 'data_at'
-CONF_HEADER_HOST = 'header_host'
 #CONF_ACCURACY = 'accuracy'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -36,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HSID): cv.string,
     vol.Required(CONF_FREQ): cv.string,
     vol.Required(CONF_AT): cv.string,
-    vol.Optional(CONF_HEADER_HOST, default='plus.google.com'): cv.string,
     #    vol.Optional(CONF_ACCURACY, default=100): cv.positive_int,
     vol.Optional(CONF_INTERVAL, default=1): vol.All(cv.positive_int,
                                                     vol.Range(min=1)),
@@ -59,15 +57,12 @@ def setup_scanner(hass, config, see):
     data_freq = config[CONF_FREQ]
     data_at = config[CONF_AT]
     url = config[CONF_URL]
-    host = config[CONF_HEADER_HOST]
 
     headers = {
-        'Host': host,
         'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0',
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.5',
         'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
-        'Referer': 'https://' + host + '/',
         'X-Same-Domain': '1',
         'Connection': 'keep-alive',
     }


### PR DESCRIPTION
**Description:**


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

**Example entry for `configuration.yaml` (if applicable):**
```yaml

```

**Checklist:**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L16
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L51

Also, the url, and the data dictionary changed for me after ~14 days.
The old one stopped working.
I had to repeat the process of obtaining those values (snooping the
network traffic when visiting the google plus page in firefox).